### PR TITLE
Update BenchmarkLink's href

### DIFF
--- a/src/BenchmarkLink.js
+++ b/src/BenchmarkLink.js
@@ -13,7 +13,7 @@ export function BenchmarkLink(props: Props) {
       target="_blank"
       href={`https://${
         props.id
-      }-92570536-gh.circle-artifacts.com/0/home/circleci/repo/scripts/benchmarks/dist/index.html`}
+      }-92570536-gh.circle-artifacts.com/0/~/repo/scripts/benchmarks/dist/index.html`}
     >
       {props.children}
     </Link>


### PR DESCRIPTION
Example links:
- old: https://11295-92570536-gh.circle-artifacts.com/0/home/circleci/repo/scripts/benchmarks/dist/index.html
- new: https://11295-92570536-gh.circle-artifacts.com/0/~/repo/scripts/benchmarks/dist/index.html

It seems that maybe the format has changed in the meantime.